### PR TITLE
Compiled eex

### DIFF
--- a/benchmarks/string_templating.ex
+++ b/benchmarks/string_templating.ex
@@ -5,23 +5,25 @@ nb_bindings = 10_000
 bindings = TemplatingBenchmarks.create_bindings(nb_bindings, variables)
 
 
-TemplatingBenchmarks.eex_templating_create(simple_template, bindings |> hd |> Keyword.keys)
+TemplatingBenchmarks.eex_compiled_templating_create(simple_template, bindings |> hd |> Keyword.keys)
 
 result1 = TemplatingBenchmarks.base_templating(simple_template, bindings)
-result2 = TemplatingBenchmarks.eex_templating_run(bindings)
+result2 = TemplatingBenchmarks.eex_templating(simple_template, bindings)
 result3 = TemplatingBenchmarks.manual_templating(simple_template, bindings)
 result4 = TemplatingBenchmarks.eex_eval_string_templating(simple_template, bindings)
+result5 = TemplatingBenchmarks.eex_compiled_templating_run(bindings)
 
 IO.inspect("ALL THE FOLLOWING SHOULD BE TRUE")
 IO.inspect(result1 == result2)
 IO.inspect(result1 == result3)
 IO.inspect(result1 == result4)
+IO.inspect(result1 == result5)
 
 
 Benchee.run(%{
   "base" => fn -> TemplatingBenchmarks.base_templating(simple_template, bindings) end,
-  # "eex" => fn -> TemplatingBenchmarks.eex_templating(simple_template, bindings) end,
-  "eex" => fn -> TemplatingBenchmarks.eex_templating_run(bindings) end,
+  "eex" => fn -> TemplatingBenchmarks.eex_templating(simple_template, bindings) end,
+  "eex_compiled" => fn -> TemplatingBenchmarks.eex_compiled_templating_run(bindings) end,
   "eex_eval_string" => fn -> TemplatingBenchmarks.eex_eval_string_templating(simple_template, bindings) end,
   "manual" => fn -> TemplatingBenchmarks.manual_templating(simple_template, bindings) end
 })
@@ -186,12 +188,12 @@ variables = [:var1, :var2, :var3, :var4]
 nb_bindings = 10_000
 
 bindings = TemplatingBenchmarks.create_bindings(nb_bindings, variables)
-TemplatingBenchmarks.eex_templating_create(complex_template, bindings |> hd |> Keyword.keys)
+TemplatingBenchmarks.eex_compiled_templating_create(complex_template, bindings |> hd |> Keyword.keys)
 
 Benchee.run(%{
   "base" => fn -> TemplatingBenchmarks.base_templating(complex_template, bindings) end,
-  # "eex" => fn -> TemplatingBenchmarks.eex_templating(complex_template, bindings) end,
-  "eex" => fn -> TemplatingBenchmarks.eex_templating_run(bindings) end,
+  "eex" => fn -> TemplatingBenchmarks.eex_templating(complex_template, bindings) end,
+  "eex_compiled" => fn -> TemplatingBenchmarks.eex_compiled_templating_run(bindings) end,
   "eex_eval_string" => fn -> TemplatingBenchmarks.eex_eval_string_templating(complex_template, bindings) end,
   "manual" => fn -> TemplatingBenchmarks.manual_templating(complex_template, bindings) end
 })

--- a/benchmarks/string_templating.ex
+++ b/benchmarks/string_templating.ex
@@ -5,8 +5,10 @@ nb_bindings = 10_000
 bindings = TemplatingBenchmarks.create_bindings(nb_bindings, variables)
 
 
+TemplatingBenchmarks.eex_templating_create(simple_template, bindings |> hd |> Keyword.keys)
+
 result1 = TemplatingBenchmarks.base_templating(simple_template, bindings)
-result2 = TemplatingBenchmarks.eex_templating(simple_template, bindings)
+result2 = TemplatingBenchmarks.eex_templating_run(bindings)
 result3 = TemplatingBenchmarks.manual_templating(simple_template, bindings)
 result4 = TemplatingBenchmarks.eex_eval_string_templating(simple_template, bindings)
 
@@ -15,9 +17,11 @@ IO.inspect(result1 == result2)
 IO.inspect(result1 == result3)
 IO.inspect(result1 == result4)
 
+
 Benchee.run(%{
   "base" => fn -> TemplatingBenchmarks.base_templating(simple_template, bindings) end,
-  "eex" => fn -> TemplatingBenchmarks.eex_templating(simple_template, bindings) end,
+  # "eex" => fn -> TemplatingBenchmarks.eex_templating(simple_template, bindings) end,
+  "eex" => fn -> TemplatingBenchmarks.eex_templating_run(bindings) end,
   "eex_eval_string" => fn -> TemplatingBenchmarks.eex_eval_string_templating(simple_template, bindings) end,
   "manual" => fn -> TemplatingBenchmarks.manual_templating(simple_template, bindings) end
 })
@@ -182,10 +186,12 @@ variables = [:var1, :var2, :var3, :var4]
 nb_bindings = 10_000
 
 bindings = TemplatingBenchmarks.create_bindings(nb_bindings, variables)
+TemplatingBenchmarks.eex_templating_create(complex_template, bindings |> hd |> Keyword.keys)
 
 Benchee.run(%{
   "base" => fn -> TemplatingBenchmarks.base_templating(complex_template, bindings) end,
-  "eex" => fn -> TemplatingBenchmarks.eex_templating(complex_template, bindings) end,
+  # "eex" => fn -> TemplatingBenchmarks.eex_templating(complex_template, bindings) end,
+  "eex" => fn -> TemplatingBenchmarks.eex_templating_run(bindings) end,
   "eex_eval_string" => fn -> TemplatingBenchmarks.eex_eval_string_templating(complex_template, bindings) end,
   "manual" => fn -> TemplatingBenchmarks.manual_templating(complex_template, bindings) end
 })

--- a/lib/templating_benchmarks.ex
+++ b/lib/templating_benchmarks.ex
@@ -8,12 +8,40 @@ defmodule TemplatingBenchmarks do
     end)
   end
 
-  def eex_templating(template, bindings) do
-    compiled = EEx.compile_string(template)
+  # def eex_templating(template, bindings) do
+  #   variable_names = bindings |> hd |> Keyword.keys
+  #   IO.inspect(variable_names, label: :variable_names)
+  #   # compiled = EEx.compile_string(template)
+  #   module_body =
+  #     quote bind_quoted: [template: template, variable_names: variable_names] do
+  #       require EEx
+  #       EEx.function_from_string(:def, :example, template, variable_names)
+  #     end
 
+  #   Module.create(EexExampleModule, module_body, Macro.Env.location(__ENV__))
+
+  #   Enum.map(bindings, fn binding ->
+  #     # {result, _} = Code.eval_quoted(compiled, binding)
+  #     # result
+  #     EexExampleModule.example(Keyword.values(binding))
+  #   end)
+  # end
+
+  def eex_templating_create(template, variable_names) do
+    module_body =
+      quote bind_quoted: [template: template, variable_names: variable_names] do
+      require EEx
+      EEx.function_from_string(:def, :example, template, variable_names)
+    end
+
+    Module.create(EexExampleModule, module_body, Macro.Env.location(__ENV__))
+  end
+
+  def eex_templating_run(bindings) do
     Enum.map(bindings, fn binding ->
-      {result, _} = Code.eval_quoted(compiled, binding)
-      result
+      # {result, _} = Code.eval_quoted(compiled, binding)
+      # result
+      apply(EexExampleModule, :example, Keyword.values(binding))
     end)
   end
 

--- a/lib/templating_benchmarks.ex
+++ b/lib/templating_benchmarks.ex
@@ -8,26 +8,16 @@ defmodule TemplatingBenchmarks do
     end)
   end
 
-  # def eex_templating(template, bindings) do
-  #   variable_names = bindings |> hd |> Keyword.keys
-  #   IO.inspect(variable_names, label: :variable_names)
-  #   # compiled = EEx.compile_string(template)
-  #   module_body =
-  #     quote bind_quoted: [template: template, variable_names: variable_names] do
-  #       require EEx
-  #       EEx.function_from_string(:def, :example, template, variable_names)
-  #     end
+  def eex_templating(template, bindings) do
+    compiled = EEx.compile_string(template)
 
-  #   Module.create(EexExampleModule, module_body, Macro.Env.location(__ENV__))
+    Enum.map(bindings, fn binding ->
+      {result, _} = Code.eval_quoted(compiled, binding)
+      result
+    end)
+  end
 
-  #   Enum.map(bindings, fn binding ->
-  #     # {result, _} = Code.eval_quoted(compiled, binding)
-  #     # result
-  #     EexExampleModule.example(Keyword.values(binding))
-  #   end)
-  # end
-
-  def eex_templating_create(template, variable_names) do
+  def eex_compiled_templating_create(template, variable_names) do
     module_body =
       quote bind_quoted: [template: template, variable_names: variable_names] do
       require EEx
@@ -37,7 +27,7 @@ defmodule TemplatingBenchmarks do
     Module.create(EexExampleModule, module_body, Macro.Env.location(__ENV__))
   end
 
-  def eex_templating_run(bindings) do
+  def eex_compiled_templating_run(bindings) do
     Enum.map(bindings, fn binding ->
       # {result, _} = Code.eval_quoted(compiled, binding)
       # result


### PR DESCRIPTION
The way you were using EEx indeed does not result in very good performance: It re-compiles the EEx template on every benchmarking iteration.

Added by this PR is an implementation using EEx's `function_from_string` to compile the EEx template _once_ and then use it during the benchmark run.

The way this code is written right now (compiling to a statically-named module) is obviously not entirely what you'd want in a real project. There you'd probably want the module name to depend on the original name of the template, for instance. Another thing you might want is another way to work with the bindings (or alternatively use EEx's `assigns`-feature.